### PR TITLE
Add git to the dockerfile

### DIFF
--- a/graphql-IDOR/Docker/Dockerfile
+++ b/graphql-IDOR/Docker/Dockerfile
@@ -1,13 +1,14 @@
 FROM alpine:3.7
 MAINTAINER Davide Cioccia <d.cioccia@dcodx.com>
 RUN apk update --no-cache && apk add python3 \
-python3-dev \
-py3-pip \ 
-bash
+    python3-dev \
+    py3-pip \
+    bash \
+    git
 
 RUN git clone https://github.com/blabla1337/skf-labs.git
 WORKDIR /skf-labs/graphql-IDOR
 
-RUN pip3 install -r requirements.txt 
+RUN pip3 install -r requirements.txt
 RUN python3 populate-database.py
 CMD [ "python3", "app.py"]


### PR DESCRIPTION
The dockerfile was missing `git` as the dependency due to which running the dockerfile would have generated the following error:

```
/bin/sh: git: not found
The command '/bin/sh -c git clone https://github.com/blabla1337/skf-labs.git' returned a non-zero code: 127
```

Also currently in dockerfile on [line 5](https://github.com/blabla1337/skf-labs/blob/master/graphql-IDOR/Docker/Dockerfile#L5) there is an extra space after the backslash which cause syntax problem for `bash` as the dependency in the next line.

I've fixed both of the issues. Let me know if anything else is needed to be done :-)