### PR TITLE
Updating Dockerfile to fix running of parameter-binding application

### DIFF
--- a/parameter-binding/Docker/Dockerfile
+++ b/parameter-binding/Docker/Dockerfile
@@ -1,30 +1,40 @@
 FROM ruby:2.3.7
 
-
+# Installing dependencies
 RUN apt-get update && apt-get install -y \ 
   build-essential \ 
   nodejs
 
-RUN git clone https://github.com/blabla1337/skf-labs.git
-WORKDIR /skf-labs/parameter-binding
-
-# Copy the Gemfile as well as the Gemfile.lock and install 
-# the RubyGems. This is a separate step so the dependencies 
-# will be cached unless changes to one of those two files 
-# are made.
-RUN gem update --system
-RUN gem install bundler && bundle install --jobs 20 --retry 5
-
-# Copy the main application.
-COPY . ./
-RUN rake db:drop db:create db:migrate db:seed
-# Expose port 3000 to the Docker host, so we can access it 
-# from the outside.
+# Exposing port 3000 for connecting to the application -p 3000:3000
 EXPOSE 3000
 
-# The main command to run when the container starts. Also 
-# tell the Rails dev server to bind to all interfaces by 
-# default.
-#CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+# Cloning SKF's parameter-binding's application
+RUN git clone https://github.com/blabla1337/skf-labs.git
 
+# Changing directory to the application -- for processing stuff later on
+WORKDIR /skf-labs/parameter-binding
 
+# Updating/Installing
+RUN gem update --system
+
+# Installing bundler and installing gems required for the rails application to run
+RUN gem install bundler && \
+	bundle install --jobs 20 --retry 5
+
+# Executing Rake's database commands
+RUN rake db:drop db:create db:migrate db:seed
+
+# Newly added instructions for getting /bin/ directory from a new application created
+# to run our own application -- due to some reason the application released/added on
+# the skf-labs doesn't have /bin/ directory in it -- which is required for the application
+# to work.
+
+# The following will create a new application with minimal config (required) and will then
+# move the /bin/ directory in our parameter-binding challenge directory and delete that
+# application later on. Solves the issue!
+RUN rails new testApplicationForBinDirectoryOnly --skip-namespace --skip-yarn --skip-gemfile --skip-git --skip-keeps --skip-action-mailer --skip-active-record --skip-active-storage --skip-puma --skip-action-cable --skip-sprockets --skip-spring --skip-listen --skip-coffee --skip-javascript --skip-turbolinks --skip-test --skip-system-test --skip-bootsnap --skip-bundle --no-rc && \
+	mv testApplicationForBinDirectoryOnly/bin/ . && \
+	rm -rfv testApplicationForBinDirectoryOnly/
+
+# Running rails server with 0.0.0.0 as host in docker and default port (i.e. 3000)
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
**Commit details:**

**Updating Dockerfile to fix running of parameter-binding application**

Newly added instructions for getting /bin/ directory from a new application created
to run our own application -- due to some reason the application release/added on
the skf-labs doesn't have /bin/ directory in it -- which is required for the application
to work.

The following will create a new application with minimal config (required) and will then
move the /bin/ directory in our parameter-binding challenge directory and delete that
application later on. Solves the issue of running the application later on!

If this doesn't happen or /bin/ directory isn't created in the application (i.e. paramter-
binding), it asks us to create a new application and the error isn't verbose either

---

Fixes the issue: https://github.com/blabla1337/skf-labs/issues/105

Here are some asciinema recordings showing the building/running of the Docker image. 

**Git diff:**
https://github.com/Anon-Exploiter/skf-labs/commit/404f008d5841e8dadbd417f1bea657c0834c0eeb 

**Building:**
[![asciicast](https://asciinema.org/a/359437.svg)](https://asciinema.org/a/359437)

**Running:**
[![asciicast](https://asciinema.org/a/359438.svg)](https://asciinema.org/a/359438)

**Application's UI:**
![image](https://user-images.githubusercontent.com/18597330/93016149-7d2c0780-f5d8-11ea-9f99-209a9ffc5b5a.png)

**Successful exploitation of vulnerability:**
![image](https://user-images.githubusercontent.com/18597330/93016170-9e8cf380-f5d8-11ea-91b2-4d34ebf85594.png)

**Confirmation:**
![image](https://user-images.githubusercontent.com/18597330/93016176-a6e52e80-f5d8-11ea-9360-1e365cb1da9c.png)

---

**Some screenshots from the terminal:**
![image](https://user-images.githubusercontent.com/18597330/93016186-b5cbe100-f5d8-11ea-8512-5e6e174abbd0.png)
![image](https://user-images.githubusercontent.com/18597330/93016190-bb292b80-f5d8-11ea-9266-826cb1c346fa.png)