### PR TITLE
Docker run command incomplete in tls-downgrade

### DIFF
--- a/kbid-xxx-tls-downgrade.md
+++ b/kbid-xxx-tls-downgrade.md
@@ -7,7 +7,7 @@ $ sudo docker pull blabla1337/owasp-skf-lab:tls-downgrade
 ```
 
 ```text
-$ sudo docker run -ti -p 127.0.0.1:5000:5000 blabla1337/owasp-skf-lab:tls-downgrade
+$ sudo docker run -ti -p 127.0.0.1:5000:5000 --cap-add=NET_ADMIN blabla1337/owasp-skf-lab:tls-downgrade
 ```
 
 {% hint style="success" %}


### PR DESCRIPTION
The docker run command was missing "--cap-add=NET_ADMIN". That's crucial for the lab to work.