### PR TITLE
Fix `java/url-redirection` POM

### DIFF
--- a/java/url-redirection/pom.xml
+++ b/java/url-redirection/pom.xml
@@ -39,8 +39,8 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins><finalName>app</finalName>
+	<build><finalName>app</finalName>
+		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out -->
In the `POM.xml` for the lab `java/url-redirection` the `<finalName>` element somehow snuck into the wrong parent element leading to the maven project not being buildable.
This PR fixes it.

